### PR TITLE
fix: change pool

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tide-diesel"
-version = "0.1.1"
+version = "0.1.2"
 authors = [
     "Bradford Toney <bradford.toney@gmail.com>",
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ where
 pub trait DieselRequestExt {
     async fn pg_conn<'req>(
         &'req self,
-    ) -> std::result::Result<PooledPgConn, Box<dyn std::error::Error + Send + Sync>>;
+    ) -> std::result::Result<PooledPgConn, Box<dyn std::error::Error + Send + Sync + 'static>>;
     async fn pg_pool_conn<'req>(&'req self) -> MutexGuard<'req, PoolPgConn>;
 }
 
@@ -65,9 +65,9 @@ pub trait DieselRequestExt {
 impl<T: Send + Sync + 'static> DieselRequestExt for Request<T> {
     async fn pg_conn<'req>(
         &'req self,
-    ) -> std::result::Result<PooledPgConn, Box<dyn std::error::Error + Send + Sync>> {
+    ) -> std::result::Result<PooledPgConn, Box<dyn std::error::Error + Send + Sync + 'static>> {
         let pg_conn: &Arc<PoolPgConn> = self.ext().expect("You must install Diesel middleware");
-        Ok(pg_conn.get()?)
+        Ok(pg_conn.get().map_err(|e| Box::new(e))?)
     }
 
     async fn pg_pool_conn<'req>(&'req self) -> MutexGuard<'req, PoolPgConn> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ where
 pub trait DieselRequestExt {
     async fn pg_conn<'req>(
         &'req self,
-    ) -> std::result::Result<PooledPgConn, Box<dyn std::error::Error + Send + Sync + 'static>>;
+    ) -> std::result::Result<PooledPgConn, diesel::r2d2::PoolError>;
     async fn pg_pool_conn<'req>(&'req self) -> MutexGuard<'req, PoolPgConn>;
 }
 
@@ -65,9 +65,9 @@ pub trait DieselRequestExt {
 impl<T: Send + Sync + 'static> DieselRequestExt for Request<T> {
     async fn pg_conn<'req>(
         &'req self,
-    ) -> std::result::Result<PooledPgConn, Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> std::result::Result<PooledPgConn, diesel::r2d2::PoolError> {
         let pg_conn: &Arc<PoolPgConn> = self.ext().expect("You must install Diesel middleware");
-        Ok(pg_conn.get().map_err(|e| Box::new(e))?)
+        pg_conn.get()
     }
 
     async fn pg_pool_conn<'req>(&'req self) -> MutexGuard<'req, PoolPgConn> {


### PR DESCRIPTION
- Add the pool as well to the middleware so that every single time we as for a `pg_conn` we get a new connection, in the case of needing the pool it has been added under `pg_pool_conn` 
- Include the `PooledConnection` as its thread safe, you can still dereference it and get a `PgConnection` or use `impl Connection<Backend = Pg>` in your database function
